### PR TITLE
Fix JavaScript SDK to reflect partial name match

### DIFF
--- a/_advanced/cards_get_by_name.md
+++ b/_advanced/cards_get_by_name.md
@@ -50,7 +50,7 @@ cards = Card.where(name='"Archangel Avacyn"').all()
 const mtg = require('mtgsdk')
 
 // partial name match
-mtg.card.where({name: '"Archangel Avacyn"'})
+mtg.card.where({name: 'Archangel Avacyn'})
 .then(results => {
     console.log(results)
 })


### PR DESCRIPTION
Exact name match and partial name match were the same. Partial match shouldn't have double quotes.